### PR TITLE
explicit conversion to float

### DIFF
--- a/openstack_metrics.py
+++ b/openstack_metrics.py
@@ -153,7 +153,7 @@ def dispatch_values(metric, value, dims, props, custdims, metric_type="gauge"):
     val.type_instance = "{0}{1}".format(metric, _formatDimsForSignalFx(dims))
     val.plugin = "openstack"
     val.plugin_instance = _formatDimsForSignalFx(props)
-    val.values = [value]
+    val.values = [float(value)]
     val.dispatch()
 
 


### PR DESCRIPTION
If the value was decimal, python is setting it as string and causing the agent to fail handling the metric with.
```
ERRO[0033] Could not handle message from Python          error="parse error: expected number near offset 521 of '0.32'" monitorID=10 monitorType=collectd/openstack runnerPID=3396
```
Signed-off-by: Dani Louca <dlouca@splunk.com>