### PR TITLE
Don't fail hypervisor metrics when uptime endpoint is not available

### DIFF
--- a/NovaMetrics.py
+++ b/NovaMetrics.py
@@ -143,10 +143,14 @@ class NovaMetrics:
 
         try:
             hypervisor = self.nova.hypervisors.get(hypervisorId)
-            uptime = self.nova.hypervisors.uptime(hypervisorId)
         except Exception:
             # In case of error, do nothing
             hypervisor = None
+        
+        try:
+            uptime = self.nova.hypervisors.uptime(hypervisorId)
+        except Exception:
+            # In case of error, do nothing
             uptime = None
 
         # Create metrics


### PR DESCRIPTION
If `uptime` endpoint is not available, the current code sets `hypervisor` data to None and prevent the code from dispatching metrics.


Signed-off-by: Dani Louca <dlouca@splunk.com>