### PR TITLE
Add region_name option

### DIFF
--- a/CinderMetrics.py
+++ b/CinderMetrics.py
@@ -23,6 +23,7 @@ class CinderMetrics:
         project_name,
         project_domain_id,
         user_domain_id,
+        region_name,
         ssl_verify
     ):
         self._auth_url = auth_url
@@ -31,6 +32,7 @@ class CinderMetrics:
         self._project_name = project_name
         self._project_domain_id = project_domain_id
         self._user_domain_id = user_domain_id
+        self._region_name = region_name
         self._ssl_verify = ssl_verify
 
         self.auth = identity.Password(
@@ -44,7 +46,8 @@ class CinderMetrics:
         self.sess = session.Session(auth=self.auth, verify=self._ssl_verify)
         self.cinder = client.Client(
             DEFAULT_CINDER_CLIENT_VERSION,
-            session=self.sess
+            session=self.sess,
+            region_name=self._region_name
         )
 
     def collect_cinder_metrics(self):
@@ -60,6 +63,8 @@ class CinderMetrics:
         props["project_name"] = self._project_name
         props["project_domain_name"] = self._project_domain_id
         props["user_domain_name"] = self._user_domain_id
+        if self._region_name:
+            props["region_name"] = self._region_name
 
         return {'0': (metrics, dims, props)}
 

--- a/NeutronMetrics.py
+++ b/NeutronMetrics.py
@@ -25,6 +25,7 @@ class NeutronMetrics:
         project_name,
         project_domain_id,
         user_domain_id,
+        region_name,
         ssl_verify
     ):
         self._auth_url = auth_url
@@ -33,6 +34,7 @@ class NeutronMetrics:
         self._project_name = project_name
         self._project_domain_id = project_domain_id
         self._user_domain_id = user_domain_id
+        self._region_name = region_name
         self._ssl_verify = ssl_verify
 
         self.auth = identity.Password(
@@ -46,7 +48,8 @@ class NeutronMetrics:
         self.sess = session.Session(auth=self.auth, verify=self._ssl_verify)
         self.neutron = client.Client(
             DEFAULT_NEUTRON_CLIENT_VERSION,
-            session=self.sess
+            session=self.sess,
+            region_name=self._region_name
         )
 
     def collect_neutron_metrics(self):
@@ -63,7 +66,9 @@ class NeutronMetrics:
         props["project_name"] = self._project_name
         props["project_domain_name"] = self._project_domain_id
         props["user_domain_name"] = self._user_domain_id
-
+        if self._region_name:
+            props["region_name"] = self._region_name
+ 
         return {'0': (metrics, dims, props)}
 
     def collect_network_metrics(self, metrics):

--- a/NovaMetrics.py
+++ b/NovaMetrics.py
@@ -112,6 +112,7 @@ class NovaMetrics:
         project_name,
         project_domain_id,
         user_domain_id,
+        region_name,
         ssl_verify
     ):
         self._auth_url = auth_url
@@ -120,6 +121,7 @@ class NovaMetrics:
         self._project_name = project_name
         self._project_domain_id = project_domain_id
         self._user_domain_id = user_domain_id
+        self._region_name = region_name
         self._ssl_verify = ssl_verify
 
         self.auth = identity.Password(
@@ -133,7 +135,8 @@ class NovaMetrics:
         self.sess = session.Session(auth=self.auth, verify=self._ssl_verify)
         self.nova = client.Client(
             DEFAULT_NOVA_CLIENT_VERSION,
-            session=self.sess
+            session=self.sess,
+            region_name=self._region_name
         )
 
     def _build_hypervisor_metrics(self, hypervisorId):
@@ -204,6 +207,8 @@ class NovaMetrics:
         props["project_name"] = self._project_name
         props["project_domain_name"] = self._project_domain_id
         props["user_domain_name"] = self._user_domain_id
+        if self._region_name:
+            props["region_name"] = self._region_name
 
         return (metrics, dims, props)
 
@@ -284,6 +289,8 @@ class NovaMetrics:
         props["project_name"] = self._project_name
         props["project_domain_name"] = self._project_domain_id
         props["user_domain_name"] = self._user_domain_id
+        if self._region_name:
+            props["region_name"] = self._region_name
 
         return (metrics, dims, props)
 
@@ -330,5 +337,7 @@ class NovaMetrics:
         props["project_name"] = self._project_name
         props["project_domain_name"] = self._project_domain_id
         props["user_domain_name"] = self._user_domain_id
+        if self._region_name:
+            props["region_name"] = self._region_name
 
         return {'0': (metrics, dims, props)}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Optional configurations keys include:
 * ProjectName - Name of the Project to be monitored, default 'demo'
 * ProjectDomainId - Domain to which the project belong to, 'default'
 * UserDomainId - Domain to which the user belong to, 'default'
+* RegionName - The region name for URL discovery, defaults to the first region if multiple regions are available.
 * Dimension - Add extra dimensions to your metrics
 * SSLVerify - Validate SSL certificate, 'True'
 

--- a/openstack_metrics.py
+++ b/openstack_metrics.py
@@ -9,6 +9,7 @@ def config_callback(conf):
     project_name = "demo"
     project_domainid = "default"
     user_domainid = "default"
+    region_name = None
     interval = 10
     testing = False
     ssl_verify = True
@@ -28,6 +29,9 @@ def config_callback(conf):
                 project_domainid = node.values[0]
             elif node.key.lower() == "userdomainid":
                 user_domainid = node.values[0]
+            elif node.key.lower() == "regionname":
+                if node.values[0]:
+                    region_name = node.values[0]
             elif node.key.lower() == "dimension":
                 if len(node.values) == 2:
                     custom_dimensions.update({node.values[0]: node.values[1]})
@@ -58,6 +62,7 @@ def config_callback(conf):
             project_name,
             project_domainid,
             user_domainid,
+            region_name,
             ssl_verify
         )
         OPENSTACK_CLIENT["nova"] = novametrics
@@ -69,6 +74,7 @@ def config_callback(conf):
             project_name,
             project_domainid,
             user_domainid,
+            region_name,
             ssl_verify
         )
         OPENSTACK_CLIENT["cinder"] = cindermetrics
@@ -80,6 +86,7 @@ def config_callback(conf):
             project_name,
             project_domainid,
             user_domainid,
+            region_name,
             ssl_verify
         )
         OPENSTACK_CLIENT["neutron"] = neutronmetrics


### PR DESCRIPTION
This enhancement gives the user the option to define the region name for URL discovery. 
Without it, the SDK defaults to the first region if multiple regions are available, which can be problematic and prevent user to monitor specific regions.

Signed-off-by: Dani Louca <dlouca@splunk.com>