### PR TITLE
set versions for dependencies requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-keystoneauth1
-python-novaclient
-python-cinderclient
-python-neutronclient
+keystoneauth1==4.3.1
+python-novaclient==17.5.0
+python-cinderclient==7.4.0
+python-neutronclient==7.4.0


### PR DESCRIPTION
The dependencies used in this repo don't have a set version and it was just a matter of time before we hit an incompatibility issue.
See this for details https://github.com/signalfx/signalfx-agent/pull/1875#issuecomment-901521783  
In a nutshell, the latest `cinderclient` module is no longer compatible with this plugin code and results of this error
````
ERRO[0009] Failed to authenticate Openstack client due to Invalid client version '2.0'. Major part should be '3'  createdTime=1.6293322102797165e+09 lineno=96 logger=root monitorID=1 monitorType=collectd/openstack runnerPID=30 sourcePath=/bundle/collectd-python/openstack/openstack_metrics.py
````

I set the version of `cinderclient` to the one right before this change https://github.com/openstack/python-cinderclient/commit/3502a5591a654ae57741c6738994ffa9d8457696 and set the others to latest version.

Signed-off-by: Dani Louca <dlouca@splunk.com>