### PR TITLE
Allow batching server metric requests, http timeouts, and nova server list options

### DIFF
--- a/CinderMetrics.py
+++ b/CinderMetrics.py
@@ -1,11 +1,6 @@
-import sys
-from os import path
-import inspect
-
 from keystoneauth1 import identity
 from keystoneauth1 import session
 from cinderclient import client
-import re
 
 METRIC_NAME_PREFIX = "openstack."
 CINDER_LIMIT_PREFIX = "cinder.limit."
@@ -24,7 +19,8 @@ class CinderMetrics:
         project_domain_id,
         user_domain_id,
         region_name,
-        ssl_verify
+        ssl_verify,
+        http_timeout
     ):
         self._auth_url = auth_url
         self._username = username
@@ -43,7 +39,7 @@ class CinderMetrics:
             project_domain_id=self._project_domain_id,
             user_domain_id=self._user_domain_id
         )
-        self.sess = session.Session(auth=self.auth, verify=self._ssl_verify)
+        self.sess = session.Session(auth=self.auth, verify=self._ssl_verify, timeout=http_timeout)
         self.cinder = client.Client(
             DEFAULT_CINDER_CLIENT_VERSION,
             session=self.sess,

--- a/NeutronMetrics.py
+++ b/NeutronMetrics.py
@@ -1,11 +1,8 @@
-import sys
-from os import path
-import inspect
+from concurrent.futures import ThreadPoolExecutor
 
 from keystoneauth1 import identity
 from keystoneauth1 import session
 from neutronclient.neutron import client
-import re
 
 METRIC_NAME_PREFIX = "openstack."
 NEUTRON_NETWORK_PREFIX = "neutron.network."
@@ -26,7 +23,8 @@ class NeutronMetrics:
         project_domain_id,
         user_domain_id,
         region_name,
-        ssl_verify
+        ssl_verify,
+        http_timeout
     ):
         self._auth_url = auth_url
         self._username = username
@@ -45,7 +43,7 @@ class NeutronMetrics:
             project_domain_id=self._project_domain_id,
             user_domain_id=self._user_domain_id
         )
-        self.sess = session.Session(auth=self.auth, verify=self._ssl_verify)
+        self.sess = session.Session(auth=self.auth, verify=self._ssl_verify, timeout=http_timeout)
         self.neutron = client.Client(
             DEFAULT_NEUTRON_CLIENT_VERSION,
             session=self.sess,

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ An OpenStack [collectd](http://www.collectd.org/) plugin which users can use to 
 ## Requirements
 
 * collectd 4.9 or later (for the Python plugin)
-* Python 2.6 or later
-* Python libraries from requirement.txt
+* Python 2.7 or later
+* Python libraries from requirements.txt (requirements-python2.txt for Python 2.7).
 
 ## Configuration
 The following are required configuration keys:
@@ -23,12 +23,17 @@ The following are required configuration keys:
 
 Optional configurations keys include:
 
-* ProjectName - Name of the Project to be monitored, default 'demo'
-* ProjectDomainId - Domain to which the project belong to, 'default'
-* UserDomainId - Domain to which the user belong to, 'default'
+* Interval - The number of seconds to wait between collections with default of 10.
+* ProjectName - Name of the Project to be monitored with default of "demo".
+* ProjectDomainId - Domain to which the project belong to with default of "default".
+* UserDomainId - Domain to which the user belong to with default of "default".
 * RegionName - The region name for URL discovery, defaults to the first region if multiple regions are available.
-* Dimension - Add extra dimensions to your metrics
-* SSLVerify - Validate SSL certificate, 'True'
+* Dimension - Dimensions name and value to add to your metrics.
+* SSLVerify - Whether to validate SSL certificates. True by default
+* HTTPTimeout - The keystone http session timeout, in seconds, for all requests. None by default.
+* RequestBatchSize - The maximum number of concurrent requests for server metrics. 5 by default.
+* QueryServerMetrics - Whether to query for Nova metrics. True by default.
+* NovaListServersSearchOpts - A yaml representation of a search options dictionary for Nova servers to query. Expanded to query parameters for https://docs.openstack.org/api-ref/compute/#list-servers.
 
 Note that multiple OpenStack projects can be configured in the same file.
 
@@ -42,9 +47,13 @@ LoadPlugin python
         AuthURL "http://localhost/identity/v3"
         Username "admin"
         Password "secret"
+        Interval 30
         ProjectName "demo"
         ProjectDomainId "default"
         UserDomainId "default"
+        HTTPTimeout 10.0
+        RequestBatchSize 20
+        NovaListServersSearchOpts "{ all_tenants: 'TRUE', status: 'ACTIVE' }" 
     </Module>
   <Module openstack_metrics>
         AuthURL "http://localhost/identity/v3"
@@ -54,6 +63,7 @@ LoadPlugin python
         ProjectDomainId "default"
         UserDomainId "default"
         SSLVerify False
+        QueryServerMetrics False
     </Module>
 </Plugin>
 ```

--- a/integration-test/10-openstack-test.conf
+++ b/integration-test/10-openstack-test.conf
@@ -5,12 +5,16 @@ LoadPlugin python
     Import openstack_metrics
 
     <Module openstack_metrics>
-        AuthURL "http://localhost/identity/v3"
+        AuthURL "http://devstack/identity/v3"
         Username "admin"
         Password "secret"
         ProjectName "demo"
         ProjectDomainId "default"
         UserDomainId "default"
+        Interval 15
+        HTTPTimeout 10.0
+        RequestBatchSize 20
+        NovaListServersSearchOpts "{ all_tenants: 'TRUE', status: 'ACTIVE' }"
     </Module>
 
 </Plugin>

--- a/integration-test/Dockerfile.collectd
+++ b/integration-test/Dockerfile.collectd
@@ -7,10 +7,14 @@ ENV COLLECTD_INTERVAL=3 COLLECTD_HOSTNAME=solr-test DISABLE_AGGREGATION=true DIS
 RUN apt-get update &&\
     apt-get install -yq netcat curl
 
-CMD /.docker/setup_openstack
-ADD integration-test/setup_openstack /.docker/setup_openstack
-
 ## The context of the image build should be the root dir of this repo!!
-ADD openstack_metrics.py /opt/collectd-openstack/
-ADD urllib_ssl_handler.py /opt/collectd-openstack/
+ADD integration-test/setup_openstack /.docker/setup_openstack
+CMD /.docker/setup_openstack
+
+RUN python -m pip install -U pip==20.3.4
+
+ADD requirements-python2.txt /opt/collectd-openstack/requirements.txt
+RUN python -m pip install -r /opt/collectd-openstack/requirements.txt
+
+ADD *.py /opt/collectd-openstack/
 ADD integration-test/10-openstack-test.conf /etc/collectd/managed_config/

--- a/integration-test/collectd.conf
+++ b/integration-test/collectd.conf
@@ -1,4 +1,4 @@
-Hostname "openstack"
+Hostname "devstack"
 Interval 10
 Timeout 2
 ReadThreads 5

--- a/integration-test/devstack/Dockerfile
+++ b/integration-test/devstack/Dockerfile
@@ -1,0 +1,79 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && \
+    apt-get -yy -q --no-install-recommends install \
+    apt-transport-https \
+    aufs-tools \
+    bridge-utils \
+    ca-certificates \
+    cifs-utils \
+    conntrack \
+    curl \
+    ebtables \
+    ethtool \
+    git \
+    glusterfs-client \
+    gnupg2 \
+    ipcalc \
+    iproute2 \
+    iptables \
+    kmod \
+    mysql-server \
+    nfs-common \
+    netcat \
+    rabbitmq-server \
+    socat \
+    software-properties-common \
+    sudo \
+    systemd
+
+ENV container docker
+RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
+    /etc/systemd/system/*.wants/* \
+    /lib/systemd/system/local-fs.target.wants/* \
+    /lib/systemd/system/sockets.target.wants/*udev* \
+    /lib/systemd/system/sockets.target.wants/*initctl* \
+    /lib/systemd/system/systemd-update-utmp*
+
+RUN systemctl set-default multi-user.target
+ENV init /lib/systemd/systemd
+
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN systemctl enable mysql
+RUN systemctl enable rabbitmq-server
+
+RUN useradd -s /bin/bash -d /opt/stack -m stack && echo "stack ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/stack && \
+    usermod -a -G mysql,rabbitmq stack
+
+RUN su - stack -c 'git clone --depth 1 https://opendev.org/openstack/devstack -b stable/stein /opt/stack/devstack'
+RUN su - stack -c 'git clone --depth 1 https://opendev.org/openstack/cinder -b stable/stein /opt/stack/cinder'
+RUN su - stack -c 'git clone --depth 1 https://opendev.org/openstack/glance -b stable/stein /opt/stack/glance'
+RUN su - stack -c 'git clone --depth 1 https://opendev.org/openstack/horizon -b stable/stein /opt/stack/horizon'
+RUN su - stack -c 'git clone --depth 1 https://opendev.org/openstack/keystone -b stable/stein /opt/stack/keystone'
+RUN su - stack -c 'git clone --depth 1 https://opendev.org/openstack/neutron -b stable/stein /opt/stack/neutron'
+RUN su - stack -c 'git clone --depth 1 https://opendev.org/openstack/nova -b stable/stein /opt/stack/nova'
+RUN su - stack -c 'git clone --depth 1 https://opendev.org/openstack/requirements -b stable/stein /opt/stack/requirements'
+
+RUN find /opt/stack/ -name "test-requirements.txt" -delete
+RUN find /opt/stack/ -mindepth 3 -name "*requirements.txt" -delete
+
+COPY local.conf /opt/stack/devstack/local.conf
+RUN chown stack:stack /opt/stack/devstack/local.conf
+
+COPY start-devstack.sh /usr/local/bin/start-devstack.sh
+RUN chmod a+x /usr/local/bin/start-devstack.sh
+
+COPY devstack.service /etc/systemd/system/devstack.service
+
+COPY stop-devstack.sh /usr/local/bin/stop-devstack.sh
+RUN chmod a+x /usr/local/bin/stop-devstack.sh
+
+VOLUME /lib/modules
+VOLUME /sys/fs/cgroup
+
+EXPOSE 80
+
+ENTRYPOINT ["/lib/systemd/systemd"]

--- a/integration-test/devstack/devstack.service
+++ b/integration-test/devstack/devstack.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=devstack
+
+[Service]
+TimeoutStartSec=1800
+TimeoutStopSec=900
+Type=forking
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/start-devstack.sh
+ExecStop=/usr/local/bin/stop-devstack.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/integration-test/devstack/local.conf
+++ b/integration-test/devstack/local.conf
@@ -1,0 +1,10 @@
+[[local|localrc]]
+disable_service tempest
+disable_service n-novnc
+disable_service etcd3
+IP_VERSION=4
+SERVICE_IP_VERSION=4
+ADMIN_PASSWORD=secret
+DATABASE_PASSWORD=$ADMIN_PASSWORD
+RABBIT_PASSWORD=$ADMIN_PASSWORD
+SERVICE_PASSWORD=$ADMIN_PASSWORD

--- a/integration-test/devstack/make-devstack-image.sh
+++ b/integration-test/devstack/make-devstack-image.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+
+docker build -t devstack:builder .
+docker run -d --privileged \
+    --name devstack \
+    -v /lib/modules:/lib/modules:ro \
+    -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+    -e container=docker \
+    devstack:builder
+
+docker exec devstack systemctl start devstack
+docker exec devstack systemctl stop devstack
+
+docker export -o /tmp/devstack.tar devstack
+# entrypoint doesn't seem to persist for all exports
+docker import -c 'ENTRYPOINT ["/lib/systemd/systemd"]' /tmp/devstack.tar devstack:latest
+
+docker rm -fv devstack
+docker rmi devstack:builder
+rm -f /tmp/devstack.tar

--- a/integration-test/devstack/start-devstack.sh
+++ b/integration-test/devstack/start-devstack.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -e
+
+### BEGIN INIT INFO
+# Provides: devstack
+# Required-Start: $local_fs $network $remote_fs
+# Required-Stop: $local_fs $network $remote_fs
+# Default-Start:  2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: devstack
+# Description: devstack
+### END INIT INFO
+
+exec &> >(tr -cd '[:print:]\n' | tee -a /var/log/start-devstack.log)
+
+function wait_for_service() {
+    local service=$1
+    local timeout=$2
+    local start_time=`date +%s`
+    echo -n "Waiting for $service to start ..."
+    while [ $(expr `date +%s` - $start_time) -lt $timeout ]; do
+        if systemctl status $service &>/dev/null; then
+            echo " OK"
+            return 0
+        fi
+        sleep 5
+    done
+    echo " FAILED"
+    systemctl status $service
+    return 1
+}
+
+function wait_for_mysql_proc() {
+    local timeout=$1
+    local start_time=`date +%s`
+    echo -n "Waiting for mysql.proc to be ready ..."
+    while [ $(expr `date +%s` - $start_time) -lt $timeout ]; do
+        if bash -o pipefail -c 'mysql -uroot -psecret -h127.0.0.1 -e "REPAIR TABLE mysql.proc;" |& grep -q "mysql\.proc.*repair.*status.*OK"'; then
+            echo " OK"
+            return 0
+        fi
+        sleep 5
+    done
+    echo " FAILED"
+    mysql -uroot -psecret -h127.0.0.1 -e "REPAIR TABLE mysql.proc;"
+    return 1
+}
+
+if ! ps -p1 | grep -q systemd; then
+    echo "systemd is not PID 1!"
+    exit 1
+fi
+
+wait_for_service rabbitmq-server 60
+
+wait_for_service mysql 60
+mysql -uroot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret';" &>/dev/null || true
+wait_for_mysql_proc 60
+
+su - stack -c 'cd /opt/stack/devstack && ./stack.sh'
+systemctl list-units --no-pager --all devstack@*

--- a/integration-test/devstack/stop-devstack.sh
+++ b/integration-test/devstack/stop-devstack.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+exec &> >(tr -cd '[:print:]\n' | tee -a /var/log/stop-devstack.log)
+
+su - stack -c 'cd /opt/stack/devstack && ./unstack.sh'

--- a/integration-test/docker-compose.yml
+++ b/integration-test/docker-compose.yml
@@ -9,11 +9,30 @@ services:
       SF_INGEST_HOST: fake_sfx
     depends_on:
       - fake_sfx
-      - openstack
+      - devstack
+      - devstack-init
 
-  openstack:
-    image: ewindisch/dockenstack
+  devstack:
+    image: devstack
+    container_name: devstack
+    # required for systemd
     privileged: true
+    volumes:
+      - /lib/modules:/lib/modules:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    ports:
+      - "8090:80"
+    environment:
+      container: docker
+    command: /lib/systemd/systemd
+
+  devstack-init:
+    image: docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    command: "docker exec devstack systemctl start devstack"
+    depends_on:
+      - devstack
 
   fake_sfx:
     build:

--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
+echo "Be sure that you have run devstack/make-devstack-image.sh before trying this."
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $DIR
 
-printf "Running tests against python2.7\n"
+echo "Running tests"
 docker-compose run --rm test
 status=$?
 
 docker-compose down
-
-printf $status
 
 exit $status

--- a/integration-test/setup_openstack
+++ b/integration-test/setup_openstack
@@ -1,16 +1,15 @@
 #!/bin/bash
 
-wait_for () {
+set -x
+
+wait_for_devstack() {
     host=$1
-    while ! nc -z $host
+    while ! curl -f http://devstack/identity/v3
     do
       sleep 0.2
     done
 }
 
-for host in openstack
-do
-  wait_for $host
-done
+wait_for_devstack
 
 exec /.docker/run.sh

--- a/integration-test/sink.py
+++ b/integration-test/sink.py
@@ -1,8 +1,6 @@
 import json
-import signal
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from time import time
 
 # This module collects metrics from collectd and can echo them back out for
 # making assertions on the collected metrics.

--- a/integration-test/test.py
+++ b/integration-test/test.py
@@ -2,37 +2,34 @@
 import http.client
 import json
 from time import time, sleep
-from subprocess import call
 
-# Quick and dirty integration test for multiple project support for openstack for
-# one collectd instance. This test script is intended to be run with
-# docker-compose with the provided docker-compose.yml configuration.
 
-# This is not very flexible but could be expanded to support other types of
-# integration tests if so desired.
-
-OPENSTACK_HOSTS = [
-    'openstack',
-]
-TIMEOUT_SECS = 180
+# Use httplib to avoid dependencies
+def get(host, port, endpoint):
+    try:
+        conn = http.client.HTTPConnection(host, port)
+        conn.request("GET", endpoint)
+        return json.loads(conn.getresponse().read())
+    except:
+        return {}
 
 
 def get_metric_data():
-    # Use httplib instead of requests so we don't have to install stuff with pip
-    conn = http.client.HTTPConnection("fake_sfx", 8080)
-    conn.request("GET", "/")
-    resp = conn.getresponse()
-    a = resp.read()
-    return json.loads(a)
+    received = get("fake_sfx", 8080, "/")
+    if len(received):
+        print("received: {0}".format(received))
+    return received
+
+
+def wait_for_openstack():
+    print("waiting to be able to reach openstack")
+    eventually_true(lambda: len(get("devstack", 80, "/compute")) > 0, 1800)
+    print("Openstack is accessible.")
 
 
 def wait_for_metrics():
-    start = time()
-    plugin = 'openstack'
-
-    print("waiting for metrics from plugin {0}".format(plugin))
-    eventually_true(lambda: any([plugin in m.get('plugin').split(':')[0] for m in get_metric_data()]),
-                    TIMEOUT_SECS - (time() - start))
+    print("waiting for metrics from plugin openstack")
+    eventually_true(lambda: any(["openstack" in m.get('plugin').split(':')[0] for m in get_metric_data()]), 500)
     print('Found!')
 
 
@@ -50,4 +47,8 @@ def eventually_true(f, timeout_secs):
 
 
 if __name__ == "__main__":
+    wait_for_openstack()
+    # takes a long time for openstack to become accessible after compute endpoint
+    print("sleeping for 10m")
+    sleep(600)
     wait_for_metrics()

--- a/openstack_metrics.py
+++ b/openstack_metrics.py
@@ -1,7 +1,12 @@
-import collectd
+import yaml
+
 from CinderMetrics import CinderMetrics
 from NeutronMetrics import NeutronMetrics
 from NovaMetrics import NovaMetrics
+
+import collectd
+
+COUNTER_METRICS = set(tuple("cpu{0}_time".format(n) for n in range(32)) + ("rx", "rx_packets", "tx", "tx_packets"))
 
 
 def config_callback(conf):
@@ -16,6 +21,11 @@ def config_callback(conf):
     OPENSTACK_CLIENT = {}
     plugin_conf = {}
     custom_dimensions = {}
+    http_timeout = None
+    request_batch_size = 5
+    nova_list_servers_search_opts = {}
+
+    query_server_metrics = True
 
     required_keys = frozenset(("authurl", "username", "password"))
 
@@ -41,9 +51,23 @@ def config_callback(conf):
                 interval = node.values[0]
             elif node.key.lower() == "sslverify":
                 ssl_verify = node.values[0]
+            elif node.key.lower() == "httptimeout":
+                http_timeout = node.values[0]
+            elif node.key.lower() == "requestbatchsize":
+                request_batch_size = int(node.values[0])
+            elif node.key.lower() == "queryservermetrics":
+                query_server_metrics = node.values[0]
+            elif node.key.lower() == "novalistserverssearchopts":
+                nova_list_servers_search_opts = yaml.load(node.values[0], Loader=yaml.FullLoader)
+                if not isinstance(nova_list_servers_search_opts, dict):
+                    raise TypeError("NovaListSeverSearchOpts must be a string representation of yaml mapping. Received {0}.".format(node.values[0]))
+            elif node.key.lower() == "testing":
+                testing = node.values[0]
         except Exception as e:
             collectd.error("Failed to load the configuration {0} due to {1}".format(node.key, e))
             raise e
+
+    OPENSTACK_CLIENT["query_server_metrics"] = query_server_metrics
 
     for key in required_keys:
         try:
@@ -51,31 +75,32 @@ def config_callback(conf):
         except KeyError:
             raise KeyError("Missing required config setting: %s" % key)
 
-    if testing:
-        return plugin_conf
-
     try:
         novametrics = NovaMetrics(
-            plugin_conf["authurl"],
-            plugin_conf["username"],
-            plugin_conf["password"],
-            project_name,
-            project_domainid,
-            user_domainid,
-            region_name,
-            ssl_verify
+            auth_url=plugin_conf["authurl"],
+            username=plugin_conf["username"],
+            password=plugin_conf["password"],
+            project_name=project_name,
+            project_domain_id=project_domainid,
+            user_domain_id=user_domainid,
+            region_name=region_name,
+            ssl_verify=ssl_verify,
+            http_timeout=http_timeout,
+            request_batch_size=request_batch_size,
+            list_servers_search_opts=nova_list_servers_search_opts,
         )
         OPENSTACK_CLIENT["nova"] = novametrics
 
         cindermetrics = CinderMetrics(
-            plugin_conf["authurl"],
-            plugin_conf["username"],
-            plugin_conf["password"],
-            project_name,
-            project_domainid,
-            user_domainid,
-            region_name,
-            ssl_verify
+            auth_url=plugin_conf["authurl"],
+            username=plugin_conf["username"],
+            password=plugin_conf["password"],
+            project_name=project_name,
+            project_domain_id=project_domainid,
+            user_domain_id=user_domainid,
+            region_name=region_name,
+            ssl_verify=ssl_verify,
+            http_timeout=http_timeout,
         )
         OPENSTACK_CLIENT["cinder"] = cindermetrics
 
@@ -87,7 +112,8 @@ def config_callback(conf):
             project_domainid,
             user_domainid,
             region_name,
-            ssl_verify
+            ssl_verify,
+            http_timeout
         )
         OPENSTACK_CLIENT["neutron"] = neutronmetrics
         OPENSTACK_CLIENT["custdims"] = custom_dimensions
@@ -95,48 +121,58 @@ def config_callback(conf):
     except Exception as e:
         collectd.error("Failed to authenticate Openstack client due to {0}".format(e))
 
+    if testing:
+        return plugin_conf, OPENSTACK_CLIENT
+
     collectd.register_read(read_callback, interval, data=OPENSTACK_CLIENT, name=project_name)
 
 
 def read_callback(data):
     try:
-        hypervisorMetrics = data["nova"].collect_hypervisor_metrics()
-        serverMetrics = data["nova"].collect_server_metrics()
-        limitMetrics = data["nova"].collect_limit_metrics()
-        blockStorageMetrics = data["cinder"].collect_cinder_metrics()
-        networkMetrics = data["neutron"].collect_neutron_metrics()
-        serverCounterMetrics = ["cpu0_time", "cpu1_time", "rx", "rx_packets", "tx", "tx_packets"]
+        custom_dims = data["custdims"]
+        to_dispatch = metrics_to_dispatch(data["nova"].collect_hypervisor_metrics, custom_dims, "hypervisor")
 
-        for hypervisor in hypervisorMetrics:
-            metrics, dims, props = hypervisorMetrics[hypervisor]
-            for (metric, value) in metrics:
-                dispatch_values(metric, value, dims, props, data["custdims"])
+        if data["query_server_metrics"]:
+            to_dispatch += server_metrics_to_dispatch(data)
 
-        for server in serverMetrics:
-            metrics, dims, props = serverMetrics[server]
-            for (metric, value) in metrics:
-                if metric.split(".")[3] in serverCounterMetrics:
-                    dispatch_values(metric, value, dims, props, data["custdims"], "counter")
-                else:
-                    dispatch_values(metric, value, dims, props, data["custdims"])
+        to_dispatch += metrics_to_dispatch(data["nova"].collect_limit_metrics, custom_dims, "limit")
+        to_dispatch += metrics_to_dispatch(data["cinder"].collect_cinder_metrics, custom_dims, "block storage")
+        to_dispatch += metrics_to_dispatch(data["neutron"].collect_neutron_metrics, custom_dims, "network")
 
-        for limit in limitMetrics:
-            metrics, dims, props = limitMetrics[limit]
-            for (metric, value) in metrics:
-                dispatch_values(metric, value, dims, props, data["custdims"])
-
-        for storage in blockStorageMetrics:
-            metrics, dims, props = blockStorageMetrics[storage]
-            for (metric, value) in metrics:
-                dispatch_values(metric, value, dims, props, data["custdims"])
-
-        for network in networkMetrics:
-            metrics, dims, props = networkMetrics[network]
-            for (metric, value) in metrics:
-                dispatch_values(metric, value, dims, props, data["custdims"])
+        for metrics in to_dispatch:
+            dispatch_values(*metrics)
 
     except Exception as e:
-        collectd.error("Failed to fetch Openstack metrics due to {0}".format(e))
+        collectd.error("Failed to dispatch Openstack metrics due to {0}".format(e))
+
+
+def metrics_to_dispatch(collector, custom_dims, metric_type):
+    to_dispatch = []
+    try:
+        for v in collector().values():
+            metrics, dims, props = v
+            for (metric, value) in metrics:
+                to_dispatch.append((metric, value, dims, props, custom_dims))
+    except Exception as e:
+        collectd.error("Failed to fetch {0} metrics due to {1}".format(metric_type, e))
+        del to_dispatch[:]
+    return to_dispatch
+
+
+def server_metrics_to_dispatch(data):
+    to_dispatch = []
+    try:
+        for v in data['nova'].collect_server_metrics().values():
+            metrics, dims, props = v
+            for (metric, value) in metrics:
+                if metric.split(".")[3] in COUNTER_METRICS:
+                    to_dispatch.append((metric, value, dims, props, data["custdims"], "counter"))
+                else:
+                    to_dispatch.append((metric, value, dims, props, data["custdims"]))
+    except Exception as e:
+        collectd.error("Failed to fetch server metrics due to {0}".format(e))
+        del to_dispatch[:]
+    return to_dispatch
 
 
 def prepare_dims(dims, custdims):

--- a/requirements-python2.txt
+++ b/requirements-python2.txt
@@ -1,6 +1,7 @@
-keystoneauth1<=4.3.1
+keystoneauth1<4.0.0
+os-client-config<2.1.0
 python-cinderclient<=7.4.0
-python-neutronclient<=7.4.0
+python-neutronclient<7.0.0
 python-novaclient<=17.5.0
 PyYAML~=5.4.1
 six~=1.16.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+mock

--- a/sample_responses.py
+++ b/sample_responses.py
@@ -1,3 +1,0 @@
-nova_metrics = {}
-cinder_metrics = {}
-neutron_metrics = {}

--- a/test_openstack.py
+++ b/test_openstack.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
+from http.server import BaseHTTPRequestHandler, HTTPServer
 import collections
 import sys
+from threading import Thread
 
 import mock
 import pytest
-
-import sample_responses
 
 
 def import_module():
@@ -28,50 +28,132 @@ def import_module():
 
 openstack_metrics = import_module()
 
+identity = """{"version": {
+    "id": "v3.12",
+    "links": [{"href": "http://127.0.0.1:8080/identity/v3/", "rel": "self"}],
+    "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}],
+    "status": "stable",
+    "updated": "2019-01-22T00:00:00Z"
+}}"""
 
-def mock_api_call(url):
-    if "nova" in url:
-        return sample_responses.nova_metrics
+tokens = """ { "token": { "audit_ids": [ "slVNmR4lRXaBjptrqGQWYA" ], "catalog": [ { "endpoints": [ { "id": "e29bbfebedc34b96890e2e1d72907cae", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "url": "http://127.0.0.1:8080/" } ], "id": "0fee659b840e44f49f1da2a859dbff1c", "name": "neutron", "type": "network" }, { "endpoints": [ { "id": "06944393f2e0405f9a26874dddd69bfe", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "url": "http://127.0.0.1:8080/volume/v3/0b67f1ab39f14260b08a017011b3e3e6" } ], "id": "4540653a4874418b8da6df25b8d005f5", "name": "cinder", "type": "block-storage" }, { "endpoints": [ { "id": "4739cb9faa1742b39a40b65b4eba5b79", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "url": "http://127.0.0.1:8080/identity" }, { "id": "d0e90d368aa542cbbf861d61cff44331", "interface": "admin", "region": "RegionOne", "region_id": "RegionOne", "url": "http://127.0.0.1:8080/identity" } ],
+                "id": "725275caac834fd486d2665771c39de5", "name": "keystone", "type": "identity" }, { "endpoints": [ { "id": "54add0a0d2c54b16a0753e12da1ba3fc", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "url": "http://127.0.0.1:8080/compute/v2/0b67f1ab39f14260b08a017011b3e3e6" } ], "id": "7eace5558c75472d866ad260489b406e",
+                "name": "nova_legacy", "type": "compute_legacy" }, { "endpoints": [ { "id": "34803e9725d342dfb039b2efb594a13e", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "url": "http://127.0.0.1:8080/compute/v2.1" } ], "id": "83f111432c11490d942758e432bd2fad",
+                "name": "nova", "type": "compute" }, { "endpoints": [ { "id": "9079570034e94ed99d7ce826f35e58e8", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "url": "http://127.0.0.1:8080/placement" } ], "id": "887ba156b0d548cd90d31d9e4d067376",
+                "name": "placement", "type": "placement" }, { "endpoints": [ { "id": "5a55f7df5bb448f7816c6441ea483e50", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "url": "http://127.0.0.1:8080/volume/v2/0b67f1ab39f14260b08a017011b3e3e6" } ], "id": "8d711b5c719c49099e5ee3720c448ce6", "name": "cinderv2",
+                "type": "volumev2" }, { "endpoints": [ { "id": "988314367a1448da88a3396482fde4e1", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "url": "http://127.0.0.1:8080/volume/v3/0b67f1ab39f14260b08a017011b3e3e6" } ], "id": "a39cb09c524741f492bcd8135ce720c6",
+                "name": "cinderv3", "type": "volumev3" }, { "endpoints": [ { "id": "64ebb125fff242b18ff58e4b47e27e14", "interface": "public", "region": "RegionOne", "region_id": "RegionOne", "url": "http://127.0.0.1:8080/image" } ], "id": "febb4bd9b64c45ce81a57974357d9e1f",
+                "name": "glance", "type": "image" } ], "expires_at": "2025-09-09T00:01:31.000000Z", "is_domain": false, "issued_at": "2021-09-08T23:01:31.000000Z", "methods": [ "password" ], "project": { "domain": { "id": "default", "name": "Default" }, "id": "0b67f1ab39f14260b08a017011b3e3e6", "name": "demo"
+        }, "roles": [ { "id": "867ec0c2b4454179bbf0abe0dd258eb8", "name": "admin" }, { "id": "d97ed88767ac4e4290cf8e190c8ac8b8", "name": "reader" }, { "id": "dfeb24871124450bb2ec15a2e899b7e3", "name": "member" } ],
+        "user": { "domain": { "id": "default", "name": "Default" }, "id": "ea6d7f93aa7a43e8b8e9088046801a5c", "name": "admin", "password_expires_at": null } } } """
 
-    if "cinder" in url:
-        return sample_responses.cinder_metrics
+search_opts_sourced = False
 
-    if "neutron" in url:
-        return sample_responses.neutron_metrics
+class MockOpenstack(BaseHTTPRequestHandler):
+    def do_GET(self):
+        response = ""
+        if self.path == "/identity/v3":
+            response = identity
+        if "/compute/v2.1/servers/detail" in self.path:
+            if self.path == "/compute/v2.1/servers/detail?all_tenants=TRUE&status=ACTIVE":
+                global search_opts_sourced
+                search_opts_sourced = True
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(bytes(response, "utf-8"))
+
+    def do_POST(self):
+        response = ""
+        self.send_response(200)
+        if self.path == "/identity/v3/auth/tokens":
+            response = tokens
+            self.send_header('X-Subject-Token', "gAAAAABhOUDLATJ_3XdR-x3DamEABFcpcBJW8mOUhSC_OoJ0-GeqKrNm8746m3H_1bK2iRvVYrxi28Y0CojHQVhoRit8IF0n43QsjWg1LBgwV8tgUUtCvDa9zhUB7mBqg3sEPudGtVzZVQc1wwCmlDGDCg9uP_iRAzfBq78eTGby_-eAVuAGeOk")
+
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(bytes(response, "utf-8"))
 
 
 ConfigOption = collections.namedtuple("ConfigOption", ("key", "values"))
 
-fail_mock_config_required_params = mock.Mock()
-fail_mock_config_required_params.children = [
-    ConfigOption("AuthURL", ("http://localhost/identity/v3",)),
-    ConfigOption("Testing", ("True")),
-]
-
 
 def test_config_fail():
+    fail_mock_config_required_params = mock.Mock()
+    fail_mock_config_required_params.children = [
+        ConfigOption("Testing", (True,)),
+        ConfigOption("AuthURL", ("http://localhost/identity/v3",)),
+    ]
+
     with pytest.raises(KeyError):
         openstack_metrics.config_callback(fail_mock_config_required_params)
 
 
-mock_config = mock.Mock()
-mock_config.children = [
-    ConfigOption("AuthURL", ("http://localhost/identity/v3",)),
-    ConfigOption("Username", ("admin",)),
-    ConfigOption("Password", ("secret",)),
-    ConfigOption("ProjectName", ("demo",)),
-    ConfigOption("ProjectDomainId", ("default",)),
-    ConfigOption("UserDomainId", ("default",)),
-    ConfigOption("Testing", ("True",)),
-]
-
-
 def test_default_config():
-    module_config = openstack_metrics.config_callback(mock_config)
+    mock_config = mock.Mock()
+    mock_config.children = [
+        ConfigOption("Testing", (True,)),
+        ConfigOption("AuthURL", ("http://localhost/identity/v3",)),
+        ConfigOption("Username", ("admin",)),
+        ConfigOption("Password", ("secret",)),
+        ConfigOption("ProjectName", ("demo",)),
+        ConfigOption("ProjectDomainId", ("default",)),
+        ConfigOption("UserDomainId", ("default",)),
+        ConfigOption("Interval", (100,)),
+        ConfigOption("SSLVerify", (True,)),
+        ConfigOption("HTTPTimeout", (123.456,)),
+        ConfigOption("RequestBatchSize", (100,)),
+        ConfigOption("QueryServerMetrics", (True,)),
+        ConfigOption("NovaListServersSearchOpts", ('{}',)),
+    ]
+
+    module_config, clients = openstack_metrics.config_callback(mock_config)
     assert module_config["authurl"] == "http://localhost/identity/v3"
     assert module_config["username"] == "admin"
     assert module_config["password"] == "secret"
+    for client in ["neutron", "nova", "cinder"]:
+        assert clients[client].sess.timeout == 123.456
+
+    assert clients["nova"]._list_servers_search_opts == {}
 
 
-def test_with_default_metrics():
-    openstack_metrics.read_callback(openstack_metrics.config_callback(mock_config))
+@pytest.fixture()
+def mock_openstack():
+    httpd = HTTPServer(("", 8080), MockOpenstack)
+    thread = Thread(target=httpd.serve_forever)
+    thread.setDaemon(True)
+    thread.start()
+    yield
+    httpd.shutdown()
+    thread.join()
+
+def test_with_default_metrics(mock_openstack):
+    mock_config = mock.Mock()
+    mock_config.children = [
+        ConfigOption("Testing", (True,)),
+        ConfigOption("AuthURL", ("http://localhost:8080/identity/v3",)),
+        ConfigOption("Username", ("admin",)),
+        ConfigOption("Password", ("secret",)),
+        ConfigOption("ProjectName", ("demo",)),
+        ConfigOption("ProjectDomainId", ("default",)),
+        ConfigOption("UserDomainId", ("default",)),
+        ConfigOption("Interval", (100,)),
+        ConfigOption("SSLVerify", (True,)),
+        ConfigOption("HTTPTimeout", (123.456,)),
+        ConfigOption("RequestBatchSize", (100,)),
+        ConfigOption("QueryServerMetrics", (True,)),
+        ConfigOption("NovaListServersSearchOpts", ('{ all_tenants: "TRUE", status: "ACTIVE" }',)),
+    ]
+
+    print("Starting metric spewer on port 8080")
+    print("Metric spewer shutting down")
+
+    _, clients = openstack_metrics.config_callback(mock_config)
+
+    assert clients["nova"]._list_servers_search_opts == {"all_tenants": "TRUE", "status": "ACTIVE"}
+
+    openstack_metrics.read_callback(clients)
+
+    assert search_opts_sourced


### PR DESCRIPTION
These changes include a few functional improvements and unrelated fixups to make (integration) testing possible again.  This project is a good candidate for larger refactoring and test coverage but I just fixed the major issues that have been brought to my attention by @dloucasfx and others that occurred to me.

1. Slightly refactor the main read_callback function to allow failures in individual metric stages without preventing general reporting.
1. New `NovaListServersSearchOpts` option that translates into query parameters to ensure that only desired tenants are queried.
1. New `QueryServerMetrics` option that prevents querying for servers when undesired by the user.
1. New `HTTPTimeout` option that is marshaled to the keystone session for all client requests.
1. New `RequestBatchSize` option that will allow server metrics to be obtained by a configurable ThreadPoolExecutor (bumps requirement to Python 2.7)
1. Set the server project_id dimension from its `tenant_id` attribute to work with TripleO deployments with service projects.
1. Increase the hardcoded threshold for cpu metrics from 2 to 32.  This would ideally be done better in the future but my approach largely just required constant updates.
1. Create new requirements-python2.txt to avoid recent breaking dep changes and restore integration test collectd image compatibility.

The integration test updates were largely enabled by the Agent's existing test service docker image: https://github.com/signalfx/signalfx-agent/tree/main/test-services/devstack (thanks to @jcheng-splunk).